### PR TITLE
Simplify usage of promises

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,17 +1,11 @@
 const axios = require("axios");
 
 const fact = {
-  async getFact() {
-    return new Promise(async (resolve, reject) => {
-      await axios
-        .get(`https://animu.ml/fact`)
-        .then(function (response) {
-          resolve(response.data);
-        })
-        .catch((err) => {
-          return reject(err);
-        });
-    });
+  getFact() {
+    return axios
+      .get(`https://animu.ml/fact`)
+      .then((response) => response.data)
   },
 };
+
 module.exports = fact;


### PR DESCRIPTION
The `getFacts` function uses `await`, `.then()`/`.catch()`, `new Promise()`, and an `async` function with no `await` call in it's scope. This can be simplified to using only one method.

## Step One

`await` is not used in this function's scope, only in the `new Promise(/* function */)` function scope

```diff
- async getFact() {
+ getFact() {
```

## Step Two

There's no need to `await` something if there's nothing after it

```diff
- return new Promise(async (resolve, reject) => {
-  await axios
+ return new Promise((resolve, reject) => {
+  axios
    .get(`https://animu.ml/fact`)
    /* more chaining */
});
```

## Step Three

There's no need to wrap `axios.get()` in a promise, as `getFact()` will return a promise either way.

```diff
- return new Promise((resolve, reject) => {
-   axios
+ return axios
     .get(`https://animu.ml/fact`)
-      .then(function (response) {
-        resolve(response.data);
-      })
-      .catch((err) => {
-         return reject(err);
-       });
+     .then((response) => response.data); 
- });
```