### PR TITLE
Remove useless breaks

### DIFF
--- a/index.js
+++ b/index.js
@@ -57,14 +57,12 @@ class AnimeFact extends EventEmitter {
                 body: res.body,
                 error: "Could not find any fact",
               };
-              break;
             case 502:
               return {
                 statusCode: res.statusCode,
                 body: res.body,
                 error: "Server down",
               };
-              break;
             default:
               return {
                 statusCode: res.statusCode,


### PR DESCRIPTION
These `break` statements are not needed because there is a `return` statement above them, which exits the `switch-case` block.

Example:
```javascript
// ...
case "foo":
  return "bar";
  break;
```

Since `return` already exits the `switch-case` statement, there is no need for a `break`. The `break` is unreachable, and hence, serves no purpose